### PR TITLE
Fix connection thrashing bug

### DIFF
--- a/bb8/src/internals.rs
+++ b/bb8/src/internals.rs
@@ -95,11 +95,10 @@ where
         }
 
         // Queue it in the idle queue
-        let conn = IdleConn::from(guard.conn.take().unwrap());
         match queue_strategy {
-            QueueStrategy::Fifo => self.conns.push_back(conn),
-            QueueStrategy::Lifo => self.conns.push_front(conn),
-        }
+            QueueStrategy::Fifo => self.conns.push_back(IdleConn::from(guard.conn.take().unwrap())),
+            QueueStrategy::Lifo => self.conns.push_front(IdleConn::from(guard.conn.take().unwrap())),
+        };
     }
 
     pub(crate) fn connect_failed(&mut self, _: Approval) {

--- a/bb8/src/internals.rs
+++ b/bb8/src/internals.rs
@@ -76,8 +76,8 @@ where
 
         // Queue it in the idle queue
         match queue_strategy {
-            QueueStrategy::Fifo => self.conns.push_back(IdleConn::from(guard.conn.take().unwrap())),
-            QueueStrategy::Lifo => self.conns.push_front(IdleConn::from(guard.conn.take().unwrap())),
+            QueueStrategy::Fifo => self.conns.push_back(IdleConn::from(conn)),
+            QueueStrategy::Lifo => self.conns.push_front(IdleConn::from(conn)),
         };
 
         self.notify.notify_one()


### PR DESCRIPTION
For some reason the previous change was causing the pool not to respect the idle timeout and cause connection thrashing